### PR TITLE
Add pagination to second level subordinates interactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,4 +55,7 @@ gem 'rack-cors'
 gem 'active_model_serializers'
 gem "rubocop-rails-omakase", require: false
 
+gem 'kaminari'
+gem 'interactor'
+
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    interactor (3.2.0)
+      ostruct
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -138,6 +140,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -366,7 +380,9 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  interactor
   kamal
+  kaminari
   puma (>= 5.0)
   rack-cors
   rails (~> 8.0.2)

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -42,11 +42,25 @@ class EmployeesController < ApplicationController
   end
 
   def second_level_subordinates
-    employee = Employee.find(params[:id])
-    result = Employees::ListSecondLevelSubordinates.new(employee).call
-    render json: result.data, status: result.status
-  end
+    page = params[:page] || 1
+    per_page = params[:per_page] || 20
 
+    employee = Employee.find_by(id: params[:id])
+    result = Employees::ListSecondLevelSubordinates.new(employee, page: page, per_page: per_page).call
+
+    if result.status == :ok
+      render json: {
+        data: ActiveModelSerializers::SerializableResource.new(result.data, each_serializer: EmployeeSerializer),
+        total: result.total,
+        total_pages: result.total_pages,
+        current_page: result.current_page,
+        per_page: result.per_page
+      }, status: :ok
+    else
+      render json: { data: result.data }, status: result.status
+    end
+  end
+  
   def peers
     employee = Employee.find(params[:id])
     result = Employees::ListPeers.new(employee).call

--- a/app/interactors/employees/list_second_level_subordinates.rb
+++ b/app/interactors/employees/list_second_level_subordinates.rb
@@ -1,22 +1,30 @@
+require 'ostruct'
+
 module Employees
   class ListSecondLevelSubordinates
-    def initialize(employee)
+    def initialize(employee, page: 1, per_page: 20)
       @employee = employee
+      @page = page.to_i
+      @per_page = per_page.to_i
     end
 
     def call
-      second_level = @employee.subordinates.flat_map(&:subordinates)
-      Result.new(true, second_level, :ok)
-    end
+      return OpenStruct.new(data: { error: "Employee not found" }, status: :not_found) unless @employee
 
-    class Result
-      attr_reader :success, :data, :status
-      def initialize(success, data, status)
-        @success = success
-        @data = data
-        @status = status
-      end
-      def success?; @success; end
+      first_level = @employee.subordinates
+      second_level = Employee.where(manager_id: first_level.select(:id))
+      total = second_level.count
+
+      paginated = second_level.offset((@page - 1) * @per_page).limit(@per_page)
+
+      OpenStruct.new(
+        data: paginated,
+        status: :ok,
+        total: total,
+        total_pages: (total.to_f / @per_page).ceil,
+        current_page: @page,
+        per_page: @per_page
+      )
     end
   end
 end

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -247,3 +247,47 @@ h2, h3 {
   text-align: right;
   padding-right: 32px;
 }
+.org-block {
+  margin-bottom: 20px;
+  padding: 16px 20px;
+  background: #f8f4fd;
+  border-radius: 14px;
+  box-shadow: 0 1px 4px rgba(205, 144, 255, 0.08);
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.org-label {
+  color: #7648ab;
+  font-weight: 700;
+  min-width: 165px;
+}
+.org-value {
+  color: #4e3786;
+  font-weight: 600;
+}
+.org-list {
+  padding-left: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.org-item {
+  list-style: none;
+  padding: 6px 12px;
+  background: #fff;
+  border-radius: 9px;
+  box-shadow: 0 1px 3px rgba(205, 144, 255, 0.04);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.org-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 14px;
+  gap: 10px;
+}

--- a/frontend/src/pages/OrgChartPage.js
+++ b/frontend/src/pages/OrgChartPage.js
@@ -6,13 +6,32 @@ function OrgChartPage({ employee, onBack }) {
   const [peers, setPeers] = useState([]);
   const [subordinates, setSubordinates] = useState([]);
   const [secondLevel, setSecondLevel] = useState([]);
+  const [secondLevelMeta, setSecondLevelMeta] = useState({});
+  const [secondLevelPage, setSecondLevelPage] = useState(1);
   const [loading, setLoading] = useState(true);
+
+  // Função para buscar os liderados 2º nível com paginação
+  const fetchSecondLevel = async (page = 1) => {
+    const res = await axios.get(
+      `http://localhost:3000/employees/${employee.id}/second_level_subordinates?page=${page}`
+    );
+    setSecondLevel(res.data.data || []);
+    // Aceita tanto meta quanto o formato flat
+    setSecondLevelMeta(
+      res.data.meta || {
+        total_pages: res.data.total_pages,
+        current_page: res.data.current_page,
+        total: res.data.total,
+        per_page: res.data.per_page,
+      }
+    );
+  };
 
   useEffect(() => {
     if (!employee) return;
-
     setLoading(true);
 
+    // Buscar gestor
     if (employee.manager_id) {
       axios.get(`http://localhost:3000/employees/${employee.manager_id}`)
         .then(res => setManager(res.data));
@@ -20,41 +39,123 @@ function OrgChartPage({ employee, onBack }) {
       setManager(null);
     }
 
+    // Buscar pares e liderados diretos
     Promise.all([
       axios.get(`http://localhost:3000/employees/${employee.id}/peers`),
-      axios.get(`http://localhost:3000/employees/${employee.id}/subordinates`),
-      axios.get(`http://localhost:3000/employees/${employee.id}/second_level_subordinates`)
-    ]).then(([peersRes, subsRes, secLevelRes]) => {
+      axios.get(`http://localhost:3000/employees/${employee.id}/subordinates`)
+    ]).then(([peersRes, subsRes]) => {
       setPeers(peersRes.data);
       setSubordinates(subsRes.data);
-      setSecondLevel(secLevelRes.data);
     }).finally(() => setLoading(false));
+
+    // Carrega liderados 2º nível página 1
+    fetchSecondLevel(1);
+    setSecondLevelPage(1);
+    // eslint-disable-next-line
   }, [employee]);
 
+  // Atualiza liderados de segundo nível ao mudar página
+  useEffect(() => {
+    if (employee) fetchSecondLevel(secondLevelPage);
+    // eslint-disable-next-line
+  }, [secondLevelPage]);
+
   if (!employee) return null;
-  if (loading) return <div className="card"><h2>Carregando organograma...</h2></div>;
+  if (loading) return (
+    <div className="card">
+      <h2>Carregando organograma...</h2>
+    </div>
+  );
 
   return (
     <div className="card">
-      <button className="button-main" onClick={onBack}>← Voltar</button>
-      <h2>Organograma de {employee.name}</h2>
-      <div style={{marginBottom: 18}}>
-        <strong>Gestor:</strong> {manager ? manager.name : <i>Nenhum gestor</i>}
+      <button className="button-main" onClick={onBack} style={{ marginBottom: 16 }}>← Voltar</button>
+      <h2 style={{ marginBottom: 28 }}>Organograma de {employee.name}</h2>
+
+      {/* Gestor */}
+      <div className="org-block">
+        <span className="org-label">Gestor:</span>
+        {manager ? (
+          <span className="org-value">{manager.name} <span className="employee-email">({manager.email})</span></span>
+        ) : (
+          <i className="org-value">Nenhum gestor</i>
+        )}
       </div>
-      <div style={{marginBottom: 12}}>
-        <strong>Pares:</strong>
-        {peers.length === 0 ? <i> Nenhum</i> :
-          <ul className="list">{peers.map(p => <li key={p.id}>{p.name}</li>)}</ul>}
+
+      {/* Pares */}
+      <div className="org-block">
+        <span className="org-label">Pares:</span>
+        {peers.length === 0 ? (
+          <i className="org-value">Nenhum</i>
+        ) : (
+          <ul className="list org-list">
+            {peers.map(p => (
+              <li key={p.id} className="org-item">
+                <span>{p.name}</span>
+                <span className="employee-email">({p.email})</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
-      <div style={{marginBottom: 12}}>
-        <strong>Liderados diretos:</strong>
-        {subordinates.length === 0 ? <i> Nenhum</i> :
-          <ul className="list">{subordinates.map(s => <li key={s.id}>{s.name}</li>)}</ul>}
+
+      {/* Liderados diretos */}
+      <div className="org-block">
+        <span className="org-label">Liderados diretos:</span>
+        {subordinates.length === 0 ? (
+          <i className="org-value">Nenhum</i>
+        ) : (
+          <ul className="list org-list">
+            {subordinates.map(s => (
+              <li key={s.id} className="org-item">
+                <span>{s.name}</span>
+                <span className="employee-email">({s.email})</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
-      <div>
-        <strong>Liderados 2º nível:</strong>
-        {secondLevel.length === 0 ? <i> Nenhum</i> :
-          <ul className="list">{secondLevel.map(s2 => <li key={s2.id}>{s2.name}</li>)}</ul>}
+
+      {/* Liderados 2º nível com paginação */}
+      <div className="org-block">
+        <span className="org-label">Liderados 2º nível:</span>
+        {secondLevel.length === 0 ? (
+          <i className="org-value">Nenhum</i>
+        ) : (
+          <>
+            <ul className="list org-list">
+              {secondLevel.map(s2 => (
+                <li key={s2.id} className="org-item">
+                  <span>{s2.name}</span>
+                  <span className="employee-email">({s2.email})</span>
+                </li>
+              ))}
+            </ul>
+            {secondLevelMeta.total_pages > 1 && (
+              <div className="org-pagination">
+                <button
+                  className="employee-org-btn"
+                  onClick={() => setSecondLevelPage(secondLevelPage - 1)}
+                  disabled={secondLevelPage <= 1}
+                  style={{ marginRight: 8 }}
+                >
+                  ← Anterior
+                </button>
+                <span style={{ fontWeight: 600, color: "#7648ab" }}>
+                  Página {secondLevelMeta.current_page || secondLevelPage} de {secondLevelMeta.total_pages}
+                </span>
+                <button
+                  className="employee-org-btn"
+                  onClick={() => setSecondLevelPage(secondLevelPage + 1)}
+                  disabled={secondLevelPage >= secondLevelMeta.total_pages}
+                  style={{ marginLeft: 8 }}
+                >
+                  Próxima →
+                </button>
+              </div>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/spec/interactors/employees/list_second_level_subordinates_spec.rb
+++ b/spec/interactors/employees/list_second_level_subordinates_spec.rb
@@ -3,13 +3,34 @@ require 'rails_helper'
 RSpec.describe Employees::ListSecondLevelSubordinates do
   let(:company) { Company.create!(name: "Org") }
   let!(:manager) { Employee.create!(company: company, name: "Boss", email: "boss@email.com") }
-  let!(:mid) { Employee.create!(company: company, name: "Mid", email: "mid@email.com", manager: manager) }
-  let!(:junior) { Employee.create!(company: company, name: "Junior", email: "junior@email.com", manager: mid) }
 
-  it "returns subordinates of subordinates" do
-    result = described_class.new(manager).call
+  before do
+    10.times do |i|
+      mid = Employee.create!(company: company, name: "Mid#{i}", email: "mid#{i}@email.com", manager: manager)
+      10.times do |j|
+        Employee.create!(company: company, name: "Junior#{i}_#{j}", email: "junior#{i}_#{j}@email.com", manager: mid)
+      end
+    end
+  end
+
+  it "returns paginated second level subordinates" do
+    result = described_class.new(manager, page: 2, per_page: 15).call
     expect(result.status).to eq(:ok)
-    expect(result.data).to include(junior)
-    expect(result.data).not_to include(mid)
+    expect(result.data.length).to eq(15)
+    expect(result.total).to eq(100)
+    expect(result.current_page).to eq(2)
+    expect(result.total_pages).to eq(7)
+  end
+
+  it "returns all on last page if less than per_page" do
+    result = described_class.new(manager, page: 7, per_page: 15).call
+    expect(result.status).to eq(:ok)
+    expect(result.data.length).to eq(10)
+  end
+
+  it "returns not found if employee missing" do
+    result = described_class.new(nil).call
+    expect(result.status).to eq(:not_found)
+    expect(result.data[:error]).to eq("Employee not found")
   end
 end


### PR DESCRIPTION
Adiciona paginação à listagem de liderados de segundo nível utilizando Kaminari, tornando a consulta mais eficiente e escalável para grandes volumes de dados, além de melhorar a experiência do usuário.

-- EN --

Adds pagination to the second-level subordinates listing using Kaminari, making queries more efficient and scalable for large datasets, while also improving user experience.

